### PR TITLE
first fix docker stack tagging

### DIFF
--- a/tasks/docker-stack.yml
+++ b/tasks/docker-stack.yml
@@ -1,16 +1,16 @@
 ---
+# jupyterhub always runs image tagged as "aiidalab-docker-stack:latest"
 - name: pull docker image from dockerhub
   become: true
   block:
     - name: pull docker image
       docker_image:
         name: aiidalab/aiidalab-docker-stack:{{ aiidalab_server_docker_stack }}
-        tag: latest
         pull: true
       register: docker_pull
     - name: tag docker image
       command: docker tag aiidalab/aiidalab-docker-stack:{{ aiidalab_server_docker_stack }} aiidalab-docker-stack:latest
-      when: docker_pull.changed
+      changed_when: false
   when: not aiidalab_server_build_locally
 
 - name: Build docker image locally
@@ -29,6 +29,6 @@
       become: true
       docker_image:
         path: "{{ ansible_env.HOME }}/aiidalab-docker-stack"
-        name: aiidalab-docker-stack
+        name: aiidalab-docker-stack:latest
         force: true
   when: aiidalab_server_build_locally

--- a/templates/jupyterhub_config.py
+++ b/templates/jupyterhub_config.py
@@ -21,7 +21,8 @@ auth_server = "{{ aiidalab_server_oauth_server }}"
 #===============================================================================
 # user Docker Spawner
 c.JupyterHub.spawner_class = 'dockerspawner.DockerSpawner'
-c.DockerSpawner.image = "aiidalab-docker-stack:{{ aiidalab_server_docker_stack }}"
+# JupyterHub always runs image tagged as "aiidalab-docker-stack:latest" on local docker instance
+c.DockerSpawner.image = "aiidalab-docker-stack:latest"
 c.DockerSpawner.extra_host_config.update({
     # take care of lost child processes
     # see also: https://github.com/krallin/tini/issues/8


### PR DESCRIPTION
in the previous version, the docker stack wasn't tagged when the image
was already present locally.
fixed now.