### PR TITLE
Modify pip packages versions:

### DIFF
--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -30,17 +30,19 @@
     version: "{{ item.version }}"
   with_items:
     - name: jupyterhub
-      version: 1.0.0
+      version: 0.9.4
     - name: jupyterhub-firstuseauthenticator
       version: 0.12
     - name: jupyter-client
       version: 5.3.3
     - name: dockerspawner
-      version: 0.11.1
+      version: 0.9.1 # Keep version to 0.9.1 otherwise the spawner will attach incorrect user's folder
     - name: oauthenticator
       version: 0.9.0
     - name: dulwich
       version: 0.19.13
+    - name: requests
+      version: 2.22.0 # To avoid warning messages from merge_app_metadata.py
 
 - name: install recent docker python library
   pip:

--- a/tasks/prerequisites.yml
+++ b/tasks/prerequisites.yml
@@ -36,13 +36,13 @@
     - name: jupyter-client
       version: 5.3.3
     - name: dockerspawner
-      version: 0.9.1 # Keep version to 0.9.1 otherwise the spawner will attach incorrect user's folder
+      version: 0.9.1  # Keep version to 0.9.1 otherwise the spawner will attach incorrect user's folder
     - name: oauthenticator
       version: 0.9.0
     - name: dulwich
       version: 0.19.13
     - name: requests
-      version: 2.22.0 # To avoid warning messages from merge_app_metadata.py
+      version: 2.22.0  # To avoid warning messages from merge_app_metadata.py
 
 - name: install recent docker python library
   pip:


### PR DESCRIPTION
* Jupyterhub is downgraded to 0.9.4

* Dockerspawner is downgraded to 0.9.1, since the newer version creates
different user's folder with respect to which jupyterhub wants to
attach user's container.

* Requests is upgraded to 2.22.0 to avoid warning messages from
merge_app_metadata.py script