### PR TITLE
making do build image configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@ aiidalab_server_create_users: false  # can be true or false
 # Set to true in order to build aiidalab docker image locally
 aiidalab_server_build_locally: false
 
+# Set to false in order to only download docker image and then manally build it
+do_build_image: true
+
 # Tag of docker stack, see https://hub.docker.com/r/aiidalab/aiidalab-docker-stack
 aiidalab_server_docker_stack: latest  # or 'develop'
 

--- a/tasks/docker-stack.yml
+++ b/tasks/docker-stack.yml
@@ -36,4 +36,5 @@
           NB_USER: "{{ aiidalab_server_user }}"
           NB_UID: "{{ aiidalab_server_uid }}"
           NB_GID: "{{ aiidalab_server_gid }}"
+      when: do_build_image
   when: aiidalab_server_build_locally


### PR DESCRIPTION
For some network problem, we wanna only download docker image locally
and then build it manually with modified Dockerfile. Therefore, make this configurable with
argument `do_build_image`. Otherwise, will stuck in the last step.