### PR TITLE
Setting permissions explicitly for apache2 and jupyterhub

### DIFF
--- a/tasks/app-metadata.yml
+++ b/tasks/app-metadata.yml
@@ -1,12 +1,21 @@
 ---
 - name: Make sure that /var/appsdata dir exists
-  file: path=/var/appsdata state=directory
+  file:
+    path: /var/appsdata
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
 - name: Copy merge_app_metadata.py script
   register: merge_script_updated
   copy:
     src: merge_app_metadata.py
     dest: /var/appsdata/merge_app_metadata.py
     force: true
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Setup cron job to run merge_app_metadata hourly
   cron:

--- a/tasks/jupyterhub.yml
+++ b/tasks/jupyterhub.yml
@@ -10,7 +10,10 @@
 - name: copy JupyterHub apache config
   template:
     src: "{{ aiidalab_apache_config }}"
-    dest: "/etc/apache2/sites-available/aiidalab-server.conf"
+    dest: /etc/apache2/sites-available/aiidalab-server.conf
+    owner: root
+    group: root
+    mode: 0644
   register: apache_config
 
 - name: enable JupyterHub apache site
@@ -30,15 +33,22 @@
   when: apache_config.changed
 
 - name: copy aiidalab logo
-  copy: src="aiidalab_wide.png" dest="/etc/jupyterhub/"
+  copy:
+    src: aiidalab_wide.png
+    dest: /etc/jupyterhub/
 
 - name: copy JupyterHub config
   template:
     src: "{{ aiidalab_server_config }}"
     dest: /etc/jupyterhub/jupyterhub_config.py
+    owner: root
+    group: root
+    mode: 0644
 
 - name: copy JupyterHub service
-  copy: src="jupyter.service" dest="/etc/systemd/system/jupyterhub.service"
+  copy:
+    src: jupyter.service
+    dest: /etc/systemd/system/jupyterhub.service
 
 - name: create JupyterHub user (adduser)
   user:
@@ -48,7 +58,12 @@
     append: true
 
 - name: create JupyterHub volumes directory
-  file: path="/var/jupyterhub/volumes" state="directory" mode=0755 owner="jupyterhub" group="jupyterhub"
+  file:
+    path: "/var/jupyterhub/volumes"
+    state: directory
+    owner: jupyterhub
+    group: jupyterhub
+    mode: 0755
 
 - name: Create and attach a volume with users home directories
   include_role:

--- a/tasks/jupyterhub.yml
+++ b/tasks/jupyterhub.yml
@@ -36,6 +36,9 @@
   copy:
     src: aiidalab_wide.png
     dest: /etc/jupyterhub/
+    owner: root
+    group: root
+    mode: 0644
 
 - name: copy JupyterHub config
   template:
@@ -49,6 +52,9 @@
   copy:
     src: jupyter.service
     dest: /etc/systemd/system/jupyterhub.service
+    owner: root
+    group: root
+    mode: 0644
 
 - name: create JupyterHub user (adduser)
   user:


### PR DESCRIPTION
To address #17 we here set the permissions explicitly on the apache and jupyterhub config files.