### PR TITLE
Made logo file customizable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+aiidalab_logo_file: aiidalab_wide.png
 aiidalab_apache_config: apache.conf
 aiidalab_server_config: jupyterhub_config.py
 aiidalab_server_mem_limit: 4G   # memory limit per user

--- a/tasks/jupyterhub.yml
+++ b/tasks/jupyterhub.yml
@@ -34,7 +34,7 @@
 
 - name: copy aiidalab logo
   copy:
-    src: aiidalab_wide.png
+    src: "{{ aiidalab_apache_config }}"
     dest: /etc/jupyterhub/
     owner: root
     group: root

--- a/tasks/jupyterhub.yml
+++ b/tasks/jupyterhub.yml
@@ -34,7 +34,7 @@
 
 - name: copy aiidalab logo
   copy:
-    src: "{{ aiidalab_apache_config }}"
+    src: "{{ aiidalab_logo_file }}"
     dest: /etc/jupyterhub/
     owner: root
     group: root


### PR DESCRIPTION
Logo can now be chosen in a playbook importing this role by overwriting the `aiidalab_logo_file` variable